### PR TITLE
add 'width_cast' method to adapt to rggen-systemverilog update

### DIFF
--- a/lib/rggen/vhdl/utility.rb
+++ b/lib/rggen/vhdl/utility.rb
@@ -20,6 +20,10 @@ module RgGen
         format('x"%0*x"', print_width, value)
       end
 
+      def width_cast(expression, _width)
+        expression
+      end
+
       def local_scope(scope_name, attributes = {}, &block)
         LocalScope.new(attributes.merge(name: scope_name), &block).to_code
       end


### PR DESCRIPTION
(refs: rggen/rggen#150, rggen/rggen-systemverilog@2d819c0fe5721f1aa480c96a46143701a6246d76)