### PR TITLE
Remove `readdatavalid` and `writeresponsevalid` signals from Avalon-MM IF

### DIFF
--- a/lib/rggen/vhdl/register_block/protocol/avalon.erb
+++ b/lib/rggen/vhdl/register_block/protocol/avalon.erb
@@ -19,8 +19,6 @@ u_adapter: entity <%= library_name %>.rggen_avalon_adapter
     i_byteenable          => <%= byteenable %>,
     i_writedata           => <%= writedata %>,
     o_waitrequest         => <%= waitrequest %>,
-    o_readdatavalid       => <%= readdatavalid %>,
-    o_writeresponsevalid  => <%= writeresponsevalid %>,
     o_response            => <%= response %>,
     o_readdata            => <%= readdata %>,
     o_register_valid      => <%= register_block.register_valid %>,

--- a/lib/rggen/vhdl/register_block/protocol/avalon.rb
+++ b/lib/rggen/vhdl/register_block/protocol/avalon.rb
@@ -21,12 +21,6 @@ RgGen.define_list_item_feature(:register_block, :protocol, :avalon) do
       output :waitrequest, {
         name: 'o_waitrequest'
       }
-      output :readdatavalid, {
-        name: 'o_readdatavalid'
-      }
-      output :writeresponsevalid, {
-        name: 'o_writeresponsevalid'
-      }
       output :response, {
         name: 'o_response', width: 2
       }

--- a/spec/rggen/vhdl/register_block/protocol/avalon_spec.rb
+++ b/spec/rggen/vhdl/register_block/protocol/avalon_spec.rb
@@ -69,14 +69,6 @@ RSpec.describe 'register_block/protocol/avalon' do
       name: 'o_waitrequest', direction: :out
     )
     expect(register_block).to have_port(
-      :readdatavalid,
-      name: 'o_readdatavalid', direction: :out
-    )
-    expect(register_block).to have_port(
-      :writeresponsevalid,
-      name: 'o_writeresponsevalid', direction: :out
-    )
-    expect(register_block).to have_port(
       :response,
       name: 'o_response', direction: :out, width: 2
     )
@@ -110,8 +102,6 @@ RSpec.describe 'register_block/protocol/avalon' do
             i_byteenable          => i_byteenable,
             i_writedata           => i_writedata,
             o_waitrequest         => o_waitrequest,
-            o_readdatavalid       => o_readdatavalid,
-            o_writeresponsevalid  => o_writeresponsevalid,
             o_response            => o_response,
             o_readdata            => o_readdata,
             o_register_valid      => register_valid,


### PR DESCRIPTION
rggen/rggen#245